### PR TITLE
Device Information Service

### DIFF
--- a/app/src/main/java/nl/rwslinkman/simdeviceble/AppModel.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/AppModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import nl.rwslinkman.simdeviceble.bluetooth.AdvertisementManager
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothDelegate
-import nl.rwslinkman.simdeviceble.device.Clock
+import nl.rwslinkman.simdeviceble.device.DigitalClock
 import nl.rwslinkman.simdeviceble.device.EarThermometer
 import nl.rwslinkman.simdeviceble.device.HeartRatePeripheral
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
@@ -95,11 +95,11 @@ class AppModel: ViewModel(), AdvertisementManager.Listener {
     }
 
     companion object {
-        val sourcesLink: String = "https://github.com/rwslinkman/simdeviceble"
-        val developerLink: String = "https://rwslinkman.nl"
+        const val sourcesLink: String = "https://github.com/rwslinkman/simdeviceble"
+        const val developerLink: String = "https://rwslinkman.nl"
         val supportedDevices: List<Device> = listOf(
             HeartRatePeripheral(),
-            Clock(),
+            DigitalClock(),
             EarThermometer()
         )
         const val defaultAllowDeviceName: Boolean = true

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/bluetooth/AdvertisementManager.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/bluetooth/AdvertisementManager.kt
@@ -17,7 +17,12 @@ class AdvertisementManager(
     var listener: Listener? = null
 ) {
     interface Listener {
-        fun updateDataContainer(characteristic: Characteristic, data: ByteArray, isInitialValue: Boolean)
+        fun updateDataContainer(
+            characteristic: Characteristic,
+            data: ByteArray,
+            isInitialValue: Boolean
+        )
+
         fun setIsAdvertising(isAdvertising: Boolean)
         fun onDeviceConnected(deviceAddress: String)
         fun onDeviceDisconnected(deviceAddress: String)
@@ -28,7 +33,7 @@ class AdvertisementManager(
         context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
     private val advertiser = bluetoothAdapter.bluetoothLeAdvertiser
     private var gattServer: BluetoothGattServer? = null
-    private val connectedDevices: MutableMap<String, BluetoothDevice> =  mutableMapOf()
+    private val connectedDevices: MutableMap<String, BluetoothDevice> = mutableMapOf()
 
     // Only used when advertising
     private lateinit var addServiceQueue: Queue<BluetoothGattService>
@@ -39,7 +44,8 @@ class AdvertisementManager(
             if (status == BluetoothGatt.GATT_SUCCESS) {
                 if (newState == BluetoothGatt.STATE_CONNECTED) {
                     device?.let {
-                        Log.i(TAG,
+                        Log.i(
+                            TAG,
                             "onConnectionStateChange: connected to ${it.name} [${it.address}]"
                         )
                         onDeviceConnected(it)
@@ -300,7 +306,7 @@ class AdvertisementManager(
             val char = device.getCharacteristic(btChar.uuid)
             char?.let {
                 var btValue = byteArrayOf()
-                if(btChar.value !== null) {
+                if (btChar.value !== null) {
                     btValue = btChar.value
                 }
                 result[char] = btValue
@@ -420,7 +426,7 @@ class AdvertisementManager(
         const val TAG = "AdvertisementManager"
         private val CLIENT_CHARACTERISTIC_CONFIGURATION_UUID =
             UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
-        private val USER_DESCRIPTION_CHARACTERISTIC_UUID = UUID
-            .fromString("00002901-0000-1000-8000-00805f9b34fb")
+        private val USER_DESCRIPTION_CHARACTERISTIC_UUID =
+            UUID.fromString("00002901-0000-1000-8000-00805f9b34fb")
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/bluetooth/BluetoothUUID.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/bluetooth/BluetoothUUID.kt
@@ -1,0 +1,11 @@
+package nl.rwslinkman.simdeviceble.bluetooth
+
+import java.util.*
+
+class BluetoothUUID {
+    companion object {
+        fun fromSigNumber(sigNumber: String): UUID {
+            return UUID.fromString("0000$sigNumber-0000-1000-8000-00805f9b34fb")
+        }
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/device/Clock.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/device/Clock.kt
@@ -4,6 +4,7 @@ import nl.rwslinkman.simdeviceble.device.model.Device
 import nl.rwslinkman.simdeviceble.device.model.Service
 import nl.rwslinkman.simdeviceble.service.battery.BatteryService
 import nl.rwslinkman.simdeviceble.service.CurrentTimeService
+import nl.rwslinkman.simdeviceble.service.deviceinformation.DeviceInformationService
 import java.util.*
 
 class Clock: Device() {
@@ -14,6 +15,7 @@ class Clock: Device() {
     override val services: List<Service>
         get() = listOf(
             BatteryService(),
-            CurrentTimeService()
+            CurrentTimeService(),
+            DeviceInformationService()
         )
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/device/DigitalClock.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/device/DigitalClock.kt
@@ -7,11 +7,13 @@ import nl.rwslinkman.simdeviceble.service.CurrentTimeService
 import nl.rwslinkman.simdeviceble.service.deviceinformation.DeviceInformationService
 import java.util.*
 
-class Clock: Device() {
+class DigitalClock: Device() {
     override val name: String
-        get() = "Digital clock"
+        get() = "Digital Clock"
+
     override val primaryServiceUuid: UUID
-        get() = UUID.randomUUID()
+        get() = CurrentTimeService.SERVICE_UUID
+
     override val services: List<Service>
         get() = listOf(
             BatteryService(),

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/device/model/Characteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/device/model/Characteristic.kt
@@ -1,19 +1,17 @@
 package nl.rwslinkman.simdeviceble.device.model
 
-import android.text.Editable
 import java.util.*
 
 interface Characteristic {
 
     enum class Type {
-        number,
-        decimal,
-        text
+        Number,
+        Text
     }
 
     val name: String
     val uuid: UUID
-//    val type: Type // TODO:
+    val type: Type
 
     val isRead: Boolean
         get() = false

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/CurrentTimeService.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/CurrentTimeService.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service
 
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import nl.rwslinkman.simdeviceble.device.model.Service
 import java.util.*
@@ -9,8 +10,12 @@ class CurrentTimeService: Service {
         get() = "CurrentTimeService"
 
     override val uuid: UUID
-        get() = UUID.fromString("00001805-0000-1000-8000-00805f9b34fb")
+        get() = SERVICE_UUID
 
     override val characteristics: List<Characteristic>
         get() = listOf()
+
+    companion object {
+        val SERVICE_UUID = BluetoothUUID.fromSigNumber("1805")
+    }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/battery/BatteryLevelCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/battery/BatteryLevelCharacteristic.kt
@@ -11,6 +11,9 @@ class BatteryLevelCharacteristic: Characteristic {
     override val uuid: UUID
         get() = UUID.fromString("00002A19-0000-1000-8000-00805f9b34fb")
 
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Number
+
     override val isRead: Boolean
         get() = true
 

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/battery/BatteryService.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/battery/BatteryService.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.battery
 
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import nl.rwslinkman.simdeviceble.device.model.Service
 import java.util.*
@@ -17,7 +18,7 @@ class BatteryService: Service {
         )
 
     companion object {
-        private val SERVICE_UUID = UUID.fromString("0000180F-0000-1000-8000-00805f9b34fb")
+        private val SERVICE_UUID = BluetoothUUID.fromSigNumber("180F")
 
         private const val INITIAL_BATTERY_LEVEL = 50
         private const val BATTERY_LEVEL_MAX = 100

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/DeviceInformationService.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/DeviceInformationService.kt
@@ -1,0 +1,25 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import nl.rwslinkman.simdeviceble.device.model.Service
+import java.util.*
+
+class DeviceInformationService: Service {
+    override val name: String
+        get() = "DeviceInformationService"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("180A")
+    override val characteristics: List<Characteristic>
+        get() = listOf(
+            ManufacturerNameCharacteristic(),
+            ModelNumberCharacteristic(),
+            SerialNumberCharacteristic(),
+            HardwareRevisionCharacteristic(),
+            FirmwareRevisionCharacteristic(),
+            SoftwareRevisionCharacteristic(),
+            SystemIdentifierCharacteristic(),
+            RegulatoryCertificationCharacteristic(),
+            PnpIdentifierCharacteristic()
+        )
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/FirmwareRevisionCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/FirmwareRevisionCharacteristic.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.deviceinformation
 
+import android.bluetooth.BluetoothGatt
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
@@ -9,18 +10,20 @@ class FirmwareRevisionCharacteristic: Characteristic {
         get() = "FirmwareRevisionCharacteristic"
     override val uuid: UUID
         get() = BluetoothUUID.fromSigNumber("2A26")
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Text
     override val isRead: Boolean
         get() = true
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
-        TODO("Not yet implemented")
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     override fun convertToPresentable(value: ByteArray): String {
-        TODO("Not yet implemented")
+        return String(value)
     }
 
     override fun convertToBytes(value: String): ByteArray {
-        TODO("Not yet implemented")
+        return value.toByteArray()
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/FirmwareRevisionCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/FirmwareRevisionCharacteristic.kt
@@ -1,0 +1,26 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import java.util.*
+
+class FirmwareRevisionCharacteristic: Characteristic {
+    override val name: String
+        get() = "FirmwareRevisionCharacteristic"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("2A26")
+    override val isRead: Boolean
+        get() = true
+
+    override fun validateWrite(offset: Int, value: ByteArray?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToPresentable(value: ByteArray): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToBytes(value: String): ByteArray {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/HardwareRevisionCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/HardwareRevisionCharacteristic.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.deviceinformation
 
+import android.bluetooth.BluetoothGatt
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
@@ -9,18 +10,20 @@ class HardwareRevisionCharacteristic: Characteristic {
         get() = "HardwareRevisionCharacteristic"
     override val uuid: UUID
         get() = BluetoothUUID.fromSigNumber("2A27")
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Text
     override val isRead: Boolean
         get() = true
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
-        TODO("Not yet implemented")
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     override fun convertToPresentable(value: ByteArray): String {
-        TODO("Not yet implemented")
+        return String(value)
     }
 
     override fun convertToBytes(value: String): ByteArray {
-        TODO("Not yet implemented")
+        return value.toByteArray()
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/HardwareRevisionCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/HardwareRevisionCharacteristic.kt
@@ -1,0 +1,26 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import java.util.*
+
+class HardwareRevisionCharacteristic: Characteristic {
+    override val name: String
+        get() = "HardwareRevisionCharacteristic"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("2A27")
+    override val isRead: Boolean
+        get() = true
+
+    override fun validateWrite(offset: Int, value: ByteArray?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToPresentable(value: ByteArray): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToBytes(value: String): ByteArray {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/ManufacturerNameCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/ManufacturerNameCharacteristic.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.deviceinformation
 
+import android.bluetooth.BluetoothGatt
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
@@ -9,18 +10,20 @@ class ManufacturerNameCharacteristic: Characteristic {
         get() = "ManufacturerNameCharacteristic"
     override val uuid: UUID
         get() = BluetoothUUID.fromSigNumber("2A29")
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Text
     override val isRead: Boolean
         get() = true
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
-        TODO("Not yet implemented")
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     override fun convertToPresentable(value: ByteArray): String {
-        TODO("Not yet implemented")
+        return String(value)
     }
 
     override fun convertToBytes(value: String): ByteArray {
-        TODO("Not yet implemented")
+        return value.toByteArray()
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/ManufacturerNameCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/ManufacturerNameCharacteristic.kt
@@ -1,0 +1,26 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import java.util.*
+
+class ManufacturerNameCharacteristic: Characteristic {
+    override val name: String
+        get() = "ManufacturerNameCharacteristic"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("2A29")
+    override val isRead: Boolean
+        get() = true
+
+    override fun validateWrite(offset: Int, value: ByteArray?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToPresentable(value: ByteArray): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToBytes(value: String): ByteArray {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/ModelNumberCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/ModelNumberCharacteristic.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.deviceinformation
 
+import android.bluetooth.BluetoothGatt
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
@@ -9,18 +10,20 @@ class ModelNumberCharacteristic: Characteristic {
         get() = "ModelNumberCharacteristic"
     override val uuid: UUID
         get() = BluetoothUUID.fromSigNumber("2A24")
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Text
     override val isRead: Boolean
         get() = true
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
-        TODO("Not yet implemented")
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     override fun convertToPresentable(value: ByteArray): String {
-        TODO("Not yet implemented")
+        return String(value)
     }
 
     override fun convertToBytes(value: String): ByteArray {
-        TODO("Not yet implemented")
+        return value.toByteArray()
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/ModelNumberCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/ModelNumberCharacteristic.kt
@@ -1,0 +1,26 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import java.util.*
+
+class ModelNumberCharacteristic: Characteristic {
+    override val name: String
+        get() = "ModelNumberCharacteristic"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("2A24")
+    override val isRead: Boolean
+        get() = true
+
+    override fun validateWrite(offset: Int, value: ByteArray?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToPresentable(value: ByteArray): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToBytes(value: String): ByteArray {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/PnpIdentifierCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/PnpIdentifierCharacteristic.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.deviceinformation
 
+import android.bluetooth.BluetoothGatt
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
@@ -9,18 +10,20 @@ class PnpIdentifierCharacteristic: Characteristic {
         get() = "PnpIdentifierCharacteristic"
     override val uuid: UUID
         get() = BluetoothUUID.fromSigNumber("2A50")
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Text
     override val isRead: Boolean
         get() = true
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
-        TODO("Not yet implemented")
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     override fun convertToPresentable(value: ByteArray): String {
-        TODO("Not yet implemented")
+        return String(value)
     }
 
     override fun convertToBytes(value: String): ByteArray {
-        TODO("Not yet implemented")
+        return value.toByteArray()
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/PnpIdentifierCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/PnpIdentifierCharacteristic.kt
@@ -1,0 +1,26 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import java.util.*
+
+class PnpIdentifierCharacteristic: Characteristic {
+    override val name: String
+        get() = "PnpIdentifierCharacteristic"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("2A50")
+    override val isRead: Boolean
+        get() = true
+
+    override fun validateWrite(offset: Int, value: ByteArray?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToPresentable(value: ByteArray): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToBytes(value: String): ByteArray {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/RegulatoryCertificationCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/RegulatoryCertificationCharacteristic.kt
@@ -1,0 +1,26 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import java.util.*
+
+class RegulatoryCertificationCharacteristic: Characteristic {
+    override val name: String
+        get() = "RegulatoryCertificationCharacteristic"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("2A2A")
+    override val isRead: Boolean
+        get() = true
+
+    override fun validateWrite(offset: Int, value: ByteArray?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToPresentable(value: ByteArray): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToBytes(value: String): ByteArray {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/RegulatoryCertificationCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/RegulatoryCertificationCharacteristic.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.deviceinformation
 
+import android.bluetooth.BluetoothGatt
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
@@ -9,18 +10,20 @@ class RegulatoryCertificationCharacteristic: Characteristic {
         get() = "RegulatoryCertificationCharacteristic"
     override val uuid: UUID
         get() = BluetoothUUID.fromSigNumber("2A2A")
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Text
     override val isRead: Boolean
         get() = true
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
-        TODO("Not yet implemented")
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     override fun convertToPresentable(value: ByteArray): String {
-        TODO("Not yet implemented")
+        return String(value)
     }
 
     override fun convertToBytes(value: String): ByteArray {
-        TODO("Not yet implemented")
+        return value.toByteArray()
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SerialNumberCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SerialNumberCharacteristic.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.deviceinformation
 
+import android.bluetooth.BluetoothGatt
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
@@ -9,18 +10,20 @@ class SerialNumberCharacteristic: Characteristic {
         get() = "SerialNumberCharacteristic"
     override val uuid: UUID
         get() = BluetoothUUID.fromSigNumber("2A25")
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Text
     override val isRead: Boolean
         get() = true
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
-        TODO("Not yet implemented")
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     override fun convertToPresentable(value: ByteArray): String {
-        TODO("Not yet implemented")
+        return String(value)
     }
 
     override fun convertToBytes(value: String): ByteArray {
-        TODO("Not yet implemented")
+        return value.toByteArray()
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SerialNumberCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SerialNumberCharacteristic.kt
@@ -1,0 +1,26 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import java.util.*
+
+class SerialNumberCharacteristic: Characteristic {
+    override val name: String
+        get() = "SerialNumberCharacteristic"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("2A25")
+    override val isRead: Boolean
+        get() = true
+
+    override fun validateWrite(offset: Int, value: ByteArray?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToPresentable(value: ByteArray): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToBytes(value: String): ByteArray {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SoftwareRevisionCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SoftwareRevisionCharacteristic.kt
@@ -1,0 +1,26 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import java.util.*
+
+class SoftwareRevisionCharacteristic: Characteristic {
+    override val name: String
+        get() = "SoftwareRevisionCharacteristic"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("2A28")
+    override val isRead: Boolean
+        get() = true
+
+    override fun validateWrite(offset: Int, value: ByteArray?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToPresentable(value: ByteArray): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToBytes(value: String): ByteArray {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SoftwareRevisionCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SoftwareRevisionCharacteristic.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.deviceinformation
 
+import android.bluetooth.BluetoothGatt
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
@@ -9,18 +10,20 @@ class SoftwareRevisionCharacteristic: Characteristic {
         get() = "SoftwareRevisionCharacteristic"
     override val uuid: UUID
         get() = BluetoothUUID.fromSigNumber("2A28")
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Text
     override val isRead: Boolean
         get() = true
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
-        TODO("Not yet implemented")
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     override fun convertToPresentable(value: ByteArray): String {
-        TODO("Not yet implemented")
+        return String(value)
     }
 
     override fun convertToBytes(value: String): ByteArray {
-        TODO("Not yet implemented")
+        return value.toByteArray()
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SystemIdentifierCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SystemIdentifierCharacteristic.kt
@@ -1,5 +1,6 @@
 package nl.rwslinkman.simdeviceble.service.deviceinformation
 
+import android.bluetooth.BluetoothGatt
 import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
@@ -9,18 +10,20 @@ class SystemIdentifierCharacteristic: Characteristic {
         get() = "SystemIdentifierCharacteristic"
     override val uuid: UUID
         get() = BluetoothUUID.fromSigNumber("2A23")
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Text
     override val isRead: Boolean
         get() = true
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
-        TODO("Not yet implemented")
+        return BluetoothGatt.GATT_SUCCESS
     }
 
     override fun convertToPresentable(value: ByteArray): String {
-        TODO("Not yet implemented")
+        return String(value)
     }
 
     override fun convertToBytes(value: String): ByteArray {
-        TODO("Not yet implemented")
+        return value.toByteArray()
     }
 }

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SystemIdentifierCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/deviceinformation/SystemIdentifierCharacteristic.kt
@@ -1,0 +1,26 @@
+package nl.rwslinkman.simdeviceble.service.deviceinformation
+
+import nl.rwslinkman.simdeviceble.bluetooth.BluetoothUUID
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import java.util.*
+
+class SystemIdentifierCharacteristic: Characteristic {
+    override val name: String
+        get() = "SystemIdentifierCharacteristic"
+    override val uuid: UUID
+        get() = BluetoothUUID.fromSigNumber("2A23")
+    override val isRead: Boolean
+        get() = true
+
+    override fun validateWrite(offset: Int, value: ByteArray?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToPresentable(value: ByteArray): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun convertToBytes(value: String): ByteArray {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/healththermometer/MeasurementIntervalCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/healththermometer/MeasurementIntervalCharacteristic.kt
@@ -18,6 +18,9 @@ class MeasurementIntervalCharacteristic: Characteristic {
     override val uuid: UUID
         get() = UUID.fromString("00002A21-0000-1000-8000-00805f9b34fb")
 
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Number
+
     override val isRead: Boolean
         get() = true
 

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/healththermometer/TemperatureMeasurementCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/healththermometer/TemperatureMeasurementCharacteristic.kt
@@ -16,6 +16,9 @@ class TemperatureMeasurementCharacteristic : Characteristic {
     override val uuid: UUID
         get() = UUID.fromString("00002A1C-0000-1000-8000-00805f9b34fb")
 
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Number
+
     override val isIndicate: Boolean
         get() = true
 

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/heartrate/BodySensorLocationCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/heartrate/BodySensorLocationCharacteristic.kt
@@ -15,6 +15,9 @@ class BodySensorLocationCharacteristic: Characteristic {
     override val uuid: UUID
         get() = CHAR_UUID
 
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Number
+
     override val isRead: Boolean
         get() = true
 

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/heartrate/HeartRateControlPointCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/heartrate/HeartRateControlPointCharacteristic.kt
@@ -1,12 +1,11 @@
 package nl.rwslinkman.simdeviceble.service.heartrate
 
 import android.bluetooth.BluetoothGatt
-import android.text.Editable
 import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
 
 /**
- * See [Heart Rate Control Point](https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_control_point.xml)
+ * Heart Rate Control Point
  */
 class HeartRateControlPointCharacteristic: Characteristic {
     override val name: String
@@ -14,6 +13,9 @@ class HeartRateControlPointCharacteristic: Characteristic {
 
     override val uuid: UUID
         get() = CHAR_UUID
+
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Number
 
     override val isWrite: Boolean
         get() = true

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/service/heartrate/HeartRateMeasurementCharacteristic.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/service/heartrate/HeartRateMeasurementCharacteristic.kt
@@ -7,7 +7,7 @@ import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import java.util.*
 
 /**
- * See [Heart Rate Measurement](https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_measurement.xml)
+ * Heart Rate Measurement
  */
 class HeartRateMeasurementCharacteristic: Characteristic {
     override val name: String
@@ -16,11 +16,17 @@ class HeartRateMeasurementCharacteristic: Characteristic {
     override val uuid: UUID
         get() = CHAR_UUID
 
+    override val type: Characteristic.Type
+        get() = Characteristic.Type.Number
+
     override val isNotify: Boolean
         get() = true
 
     override val description: String?
         get() = HEART_RATE_MEASUREMENT_DESCRIPTION
+
+    override val initialValue: ByteArray?
+        get() = INITIAL_HEART_RATE_MEASUREMENT_VALUE.toString().toByteArray()
 
     override fun validateWrite(offset: Int, value: ByteArray?): Int {
         // TODO

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/ui/data/ServiceDataAdapter.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/ui/data/ServiceDataAdapter.kt
@@ -9,6 +9,7 @@ import nl.rwslinkman.simdeviceble.device.model.Characteristic
 import nl.rwslinkman.simdeviceble.device.model.Service
 import nl.rwslinkman.simdeviceble.ui.data.controls.CharacteristicControls
 import nl.rwslinkman.simdeviceble.ui.data.controls.NumberCharacteristicControls
+import nl.rwslinkman.simdeviceble.ui.data.controls.TextCharacteristicControls
 import java.util.*
 
 class ServiceDataAdapter(private val listener: CharacteristicManipulationListener): RecyclerView.Adapter<ServiceDataViewHolder>() {
@@ -51,9 +52,11 @@ class ServiceDataAdapter(private val listener: CharacteristicManipulationListene
             charViewHolder.valueView.text = charValue
 
             var updateControls: CharacteristicControls? = null
-            // TODO Chose updateControls type based on characteristic
             if (charItem.isRead) {
-                updateControls = NumberCharacteristicControls()
+                updateControls = when(charItem.type) {
+                    Characteristic.Type.Number -> NumberCharacteristicControls()
+                    else -> TextCharacteristicControls()
+                }
             }
 
             updateControls?.let {

--- a/app/src/main/java/nl/rwslinkman/simdeviceble/ui/data/controls/TextCharacteristicControls.kt
+++ b/app/src/main/java/nl/rwslinkman/simdeviceble/ui/data/controls/TextCharacteristicControls.kt
@@ -1,0 +1,37 @@
+package nl.rwslinkman.simdeviceble.ui.data.controls
+
+import android.text.Editable
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import nl.rwslinkman.simdeviceble.R
+import nl.rwslinkman.simdeviceble.device.model.Characteristic
+import nl.rwslinkman.simdeviceble.ui.data.ServiceDataAdapter
+
+class TextCharacteristicControls: CharacteristicControls {
+
+    private lateinit var valueControl: EditText
+    private lateinit var valueUpdateButton: Button
+    private lateinit var notifyButton: Button
+
+    override val controlsLayoutId: Int
+        get() = R.layout.characteristic_update_control_text
+
+    override fun setup(controlsView: View) {
+        valueControl = controlsView.findViewById(R.id.characterstic_control_edittext)
+        valueUpdateButton  = controlsView.findViewById(R.id.characteristic_control_set_btn)
+        notifyButton = controlsView.findViewById(R.id.characteristic_control_notify_btn)
+    }
+
+    override fun bind(charItem: Characteristic, listener: ServiceDataAdapter.CharacteristicManipulationListener) {
+        valueUpdateButton.setOnClickListener {
+            val fieldValue: Editable = valueControl.text
+            listener.setCharacteristicValue(charItem, fieldValue)
+        }
+
+        notifyButton.isEnabled = charItem.isNotify
+        notifyButton.setOnClickListener {
+            listener.notifyCharacteristic(charItem)
+        }
+    }
+}

--- a/app/src/main/res/layout/characteristic_update_control_text.xml
+++ b/app/src/main/res/layout/characteristic_update_control_text.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:weightSum="3">
+
+    <EditText
+        android:id="@+id/characterstic_control_edittext"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:inputType="text"
+        />
+
+    <Button
+        android:id="@+id/characteristic_control_set_btn"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="Set"
+        />
+
+    <Button
+        android:id="@+id/characteristic_control_notify_btn"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="Notify"
+        />
+
+</LinearLayout>


### PR DESCRIPTION
Added GATT service "Device Information Service" with associated GATT characteristics.

This includes the TextControls feature in the Service Data fragment.
It is now possible to set text values to the characteristics, next to the already supported numbers.
All characteristics are now forced to have a `type` which is an enum.